### PR TITLE
add item types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js}]
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -26,6 +26,7 @@ export class CairnActor extends Actor {
 
     data.armor = actorData
       .items
+      .filter(item => item.type == 'armor' || item.type == 'item')
       .map(item => item.data.armor * item.data.equipped)
       .reduce((a, b) => a + b, 0)
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -15,7 +15,7 @@ export class CairnItemSheet extends ItemSheet {
   /** @override */
   get template () {
     const path = 'systems/cairn/templates/item'
-    return `${path}/item-sheet.html`
+    return `${path}/${this.item.data.type}-sheet.html`
   }
 
   /* -------------------------------------------- */

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -11,9 +11,7 @@ export class CairnItem extends Item {
 
     // Get the Item's data
     const itemData = this.data
-    const actorData = this.actor
-      ? this.actor.data
-      : {}
+    const actorData = this.actor ? this.actor.data : {}
     const data = itemData.data
   }
 }

--- a/template.json
+++ b/template.json
@@ -33,18 +33,37 @@
   },
   "Item": {
     "types": [
-      "item"
+      "item",
+      "weapon",
+      "armor",
+      "spellbook"
     ],
+    "templates": {
+      "universal": {
+        "description": "",
+        "quantity": 1,
+        "equipped": false,
+        "slots": 1
+      }
+    },
     "item": {
-      "description": "",
-      "quantity": 1,
+      "templates": ["base", "universal"],
       "armor": 0,
       "damageFormula": "",
       "equipped": false,
-      "bulky": false,
-      "blast": false,
-      "slots": 1,
       "numberOfUses": 0
-    }
+    },
+    "weapon": {
+      "templates":["base", "universal"],
+      "damageFormula": "",
+      "bulky": false,
+      "blast": false
+    },
+    "armor": {
+      "templates": ["base", "universal"],
+      "bulky": false,
+      "armor": 1
+    },
+    "spellbook": { "templates": ["base", "universal"] }
   }
 }

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -1,0 +1,84 @@
+<form
+    class="{{cssClass}}"
+    autocomplete="off">
+    <header class="sheet-header">
+        <img
+            class="profile-img"
+            src="{{item.img}}"
+            data-edit="img"
+            title="{{item.name}}"/>
+        <div class="header-fields">
+            <h1 class="charname"><input
+                name="name"
+                type="text"
+                value="{{item.name}}"
+                placeholder="Name"/></h1>
+            <div class="grid grid-2col">
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Bulky</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.bulky}}
+                        name="data.bulky"
+                        style="display: inline"
+                        value="{{data.bulky}}"
+                        data-dtype="Boolean"/>
+                </div>
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Equipped</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.equipped}}
+                        name="data.equipped"
+                        style="display: inline"
+                        value="{{data.equipped}}"
+                        data-dtype="Boolean"/>
+                </div>
+            </div>
+          </div>
+        </div>
+    </header>
+
+    <div class="grid grid-3col">
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Quantity</label>
+            <input
+                type="text"
+                name="data.quantity"
+                value="{{data.quantity}}"
+                data-dtype="Number"/>
+        </div>
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Slots</label>
+            <input
+                type="text"
+                name="data.slots"
+                value="{{data.slots}}"
+                placeholder=0
+                data-dtype="Number"/>
+        </div>
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Armor</label>
+            <input
+                type="text"
+                name="data.armor"
+                value="{{data.armor}}"
+                data-dtype="Number"/>
+        </div>
+    </div>
+    <div class="sheet-tabs-container">
+        <nav
+            class="sheet-tabs tabs"
+            data-group="primary">
+            <span
+                class="item"
+                data-tab="description">Description</span>
+        </nav>
+    </div>
+
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+</form>

--- a/templates/item/spellbook-sheet.html
+++ b/templates/item/spellbook-sheet.html
@@ -1,0 +1,68 @@
+<form
+    class="{{cssClass}}"
+    autocomplete="off">
+    <header class="sheet-header">
+        <img
+            class="profile-img"
+            src="{{item.img}}"
+            data-edit="img"
+            title="{{item.name}}"/>
+        <div class="header-fields">
+            <h1 class="charname"><input
+                name="name"
+                type="text"
+                value="{{item.name}}"
+                placeholder="Name"/></h1>
+
+            <div class="grid grid-3col">
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Equipped</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.equipped}}
+                        name="data.equipped"
+                        style="display: inline"
+                        value="{{data.equipped}}"
+                        data-dtype="Boolean"/>
+                </div>
+
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Slots</label>
+                    <input
+                        type="text"
+                        name="data.slots"
+                        style="display: inline"
+                        value="{{data.slots}}"
+                        placeholder=0
+                        data-dtype="Number"/>
+                </div>
+
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Quantity</label>
+                    <input
+                        type="text"
+                        name="data.quantity"
+                        style="display: inline"
+                        value="{{data.quantity}}"
+                        data-dtype="Number"/>
+                </div>
+            </div>
+          </div>
+        </div>
+
+    </header>
+
+    <div class="sheet-tabs-container">
+        <nav
+            class="sheet-tabs tabs"
+            data-group="primary">
+            <span
+                class="item"
+                data-tab="description">Description</span>
+        </nav>
+    </div>
+
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+</form>

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -1,0 +1,92 @@
+<form
+    class="{{cssClass}}"
+    autocomplete="off">
+    <header class="sheet-header">
+        <img
+            class="profile-img"
+            src="{{item.img}}"
+            data-edit="img"
+            title="{{item.name}}"/>
+        <div class="header-fields">
+            <h1 class="charname"><input
+                name="name"
+                type="text"
+                value="{{item.name}}"
+                placeholder="Name"/></h1>
+            <div class="grid grid-3col">
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Heavy</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.bulky}}
+                        name="data.bulky"
+                        value="{{data.data.bulky}}"
+                        data-dtype="Boolean"/>
+                </div>
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Equipped</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.equipped}}
+                        name="data.equipped"
+                        value="{{data.data.equipped}}"
+                        data-dtype="Boolean"/>
+                </div>
+                <div class="resource flex-group-center">
+                    <label class="resource-label" style="text-align: center">Blast</label>
+                    <input
+                        class="checkbox-block"
+                        type="checkbox"
+                        {{checked
+                        data.blast}}
+                        name="data.blast"
+                        value="{{data.data.blast}}"
+                        data-dtype="Boolean"/>
+                </div>
+            </div>
+          </div>
+        </div>
+    </header>
+
+    <div class="grid grid-3col">
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Quantity</label>
+            <input
+                type="text"
+                name="data.quantity"
+                value="{{data.quantity}}"
+                data-dtype="Number"/>
+        </div>
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Slots</label>
+            <input
+                type="text"
+                name="data.slots"
+                value="{{data.slots}}"
+                placeholder=0
+                data-dtype="Number"/>
+        </div>
+        <div class="resource flex-group-center">
+            <label class="resource-label" style="text-align: center">Damage</label>
+            <input
+                type="text"
+                name="data.damageFormula"
+                value="{{data.damageFormula}}"/>
+        </div>
+    </div>
+    <div class="sheet-tabs-container">
+        <nav
+            class="sheet-tabs tabs"
+            data-group="primary">
+            <span
+                class="item"
+                data-tab="description">Description</span>
+        </nav>
+    </div>
+
+    {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+</form>


### PR DESCRIPTION
Adds item types to Cairn so that each individual item doesn't need to have information that is irrelevant for it (armor for weapons, weapon dice for spells, etc.)


![test-item-types-cairn](https://user-images.githubusercontent.com/4121835/116813011-ee153500-ab51-11eb-9cd6-0f523f5b5857.gif)

<img width="496" alt="image" src="https://user-images.githubusercontent.com/4121835/116813042-19981f80-ab52-11eb-8823-da9e0ab8d6ca.png">

<img width="493" alt="image" src="https://user-images.githubusercontent.com/4121835/116813072-4ba98180-ab52-11eb-9053-e1bd47f67598.png">

<img width="488" alt="image" src="https://user-images.githubusercontent.com/4121835/116813082-5cf28e00-ab52-11eb-917c-19bec7fe6b2b.png">

And they all still work in the character's item section

<img width="586" alt="image" src="https://user-images.githubusercontent.com/4121835/116813107-7693d580-ab52-11eb-9024-4ca986c72e56.png">

