### PR TITLE
Update styles for new item types

### DIFF
--- a/css/cairn.css
+++ b/css/cairn.css
@@ -138,12 +138,19 @@
     border-radius: 5px 5px 0 0;
     border: 2px solid #000;
     /* border-bottom: 0; */
+    max-width: 130px;
+    max-height: 130px;
 }
 .cairn .sheet-header .header-fields {
     -webkit-box-flex: 2.2;
     -ms-flex: 2.2;
     flex: 2.2;
 }
+
+.cairn .sheet-header .flex-group-center {
+  padding: 0px; 
+}
+
 .cairn .sheet-header h1.charname {
     /*height: 40px;*/
     padding: 8px;
@@ -278,6 +285,7 @@ h2.background input {
     flex: 0 0 24px;
     margin-right: 5px;
 }
+
 .cairn .items-list .item img {
     display: block;
 }

--- a/templates/item/armor-sheet.html
+++ b/templates/item/armor-sheet.html
@@ -13,7 +13,7 @@
                 type="text"
                 value="{{item.name}}"
                 placeholder="Name"/></h1>
-            <div class="grid grid-2col">
+            <div class="grid grid-2col" style="margin-bottom: 0px">
                 <div class="resource flex-group-center">
                     <label class="resource-label" style="text-align: center">Bulky</label>
                     <input

--- a/templates/item/spellbook-sheet.html
+++ b/templates/item/spellbook-sheet.html
@@ -14,7 +14,7 @@
                 value="{{item.name}}"
                 placeholder="Name"/></h1>
 
-            <div class="grid grid-3col">
+            <div class="grid grid-3col" style="margin-bottom: 0px">
                 <div class="resource flex-group-center">
                     <label class="resource-label" style="text-align: center">Equipped</label>
                     <input

--- a/templates/item/weapon-sheet.html
+++ b/templates/item/weapon-sheet.html
@@ -13,15 +13,16 @@
                 type="text"
                 value="{{item.name}}"
                 placeholder="Name"/></h1>
-            <div class="grid grid-3col">
+            <div class="grid grid-3col" style="margin-bottom: 0px">
                 <div class="resource flex-group-center">
-                    <label class="resource-label" style="text-align: center">Heavy</label>
+                    <label class="resource-label" style="text-align: center">Bulky</label>
                     <input
                         class="checkbox-block"
                         type="checkbox"
                         {{checked
                         data.bulky}}
                         name="data.bulky"
+                        style="display: inline"
                         value="{{data.data.bulky}}"
                         data-dtype="Boolean"/>
                 </div>
@@ -33,6 +34,7 @@
                         {{checked
                         data.equipped}}
                         name="data.equipped"
+                        style="display: inline"
                         value="{{data.data.equipped}}"
                         data-dtype="Boolean"/>
                 </div>
@@ -44,6 +46,7 @@
                         {{checked
                         data.blast}}
                         name="data.blast"
+                        style="display: inline"
                         value="{{data.data.blast}}"
                         data-dtype="Boolean"/>
                 </div>


### PR DESCRIPTION
The new item types have fewer form fields than the original default item, which makes them look funny with the long rectangular images. This change makes it so that the images are expected to be square and will style them to fit on the same row as the first row of form fields. 

e.g. 
![image](https://user-images.githubusercontent.com/4121835/117497650-0d102e80-af79-11eb-8477-17f57cec3790.png)
