### PR TITLE
Update NPC armor

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -16,6 +16,7 @@ export class CairnActor extends Actor {
     // Make separate methods for each Actor type (character, npc, etc.) to keep
     // things organized.
     if (actorData.type === 'character') this._prepareCharacterData(actorData)
+    if (actorData.type === 'npc') this._prepareNpcData(actorData)
   }
 
   /**
@@ -40,6 +41,18 @@ export class CairnActor extends Actor {
     if (data.encumbered) {
       data.hp.value = 0
     }
+  }
+
+  _prepareNpcData (actorData) {
+    const data = actorData.data
+
+    let itemArmor = actorData
+      .items
+      .filter(item => item.type == 'armor' || item.type == 'item')
+      .map(item => item.data.armor * item.data.equipped)
+      .reduce((a, b) => a + b, 0)
+
+    data.armor = Math.max(itemArmor, data.armor)
   }
 
   /** @override */

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -62,8 +62,8 @@
                                 <span>
                                   <input
                                   type="text"
-                                  name="data.armor.value"
-                                  value="{{data.armor.value}}"
+                                  name="data.armor"
+                                  value="{{data.armor}}"
                                   data-dtype="Number"
                                   />
                                 </span>


### PR DESCRIPTION
In creating the new NPC actor type I added an armor field and made their templates use that value. This means that you can just type in a monster's armor rather than having to give the monster armor items. 

However the existing monsters that had been created were given armor items. Rather than update the armor to reflect those values, I updated the armor calculation for NPCs to either take an armor value stored on the monster, _or_ the sum of the armor they were carrying, whichever is higher. 

This enables GMs using this system to use whichever approach is easier for them at the table. If you create a new NPC and just want to quickly give them an armor value you can do that. But you can also add armor as items and it will calculate the armor accordingly.

As an example here's our Ankheg whose Chitanous skin gives it an armor of 2

<img width="588" alt="image" src="https://user-images.githubusercontent.com/4121835/117951452-7941b800-b314-11eb-8a22-cde415d26990.png">

If we wanted to make one that was particularly tough and just override it on the fly we could give it some other armor value, even something ridiculous

<img width="587" alt="image" src="https://user-images.githubusercontent.com/4121835/117951577-96768680-b314-11eb-911c-bb9999dae2d2.png">

We can then reset the armor back to the calculated value by replacing the armor value with 0


https://user-images.githubusercontent.com/4121835/117951943-f40ad300-b314-11eb-9892-7428f26ae438.mp4



