### PR TITLE
Disable restore abilities when deprived

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -80,11 +80,14 @@ export class CairnActorSheet extends ActorSheet {
           await this.actor.update({ 'data.hp.value': this.actor.data.data.hp.max })
         }
       })
+
     html.find('.restore')
       .click(async ev => {
-        await this.actor.update({ 'data.abilities.STR.value': this.actor.data.data.abilities.STR.max })
-        await this.actor.update({ 'data.abilities.DEX.value': this.actor.data.data.abilities.DEX.max })
-        await this.actor.update({ 'data.abilities.WIL.value': this.actor.data.data.abilities.WIL.max })
+        if (!this.actor.data.data.deprived) {
+          await this.actor.update({ 'data.abilities.STR.value': this.actor.data.data.abilities.STR.max })
+          await this.actor.update({ 'data.abilities.DEX.value': this.actor.data.data.abilities.DEX.max })
+          await this.actor.update({ 'data.abilities.WIL.value': this.actor.data.data.abilities.WIL.max })
+        }
       })
   }
 

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -33,23 +33,23 @@
                 </div>
             </div>
             {{#unless data.deprived}}
-            <span>
-                <button style="
-                width: 150px;"
-                type="button"
-                title="Rest"
-                class="rest">Rest
-                </button>
-            </span>
+              <span>
+                  <button style="
+                  width: 150px;"
+                  type="button"
+                  title="Rest"
+                  class="rest">Rest
+                  </button>
+              </span>
+              <span>
+                  <button style="
+                  width: 150px;"
+                  type="button"
+                  title="Rest"
+                  class="restore">Restore Abilities
+                  </button>
+              </span>
             {{/unless}}
-            <span>
-                <button style="
-                width: 150px;"
-                type="button"
-                title="Rest"
-                class="restore">Restore Abilities
-                </button>
-            </span>
         </div>
         <div class="header-fields">
             <h1 class="charname">


### PR DESCRIPTION
Pretty self-explanatory. Being deprived is supposed to keep you from being able to rest and restore abilities until you get un-deprived. Right now it only disables rest. This change makes it do both

https://user-images.githubusercontent.com/4121835/118361955-c41a3480-b58d-11eb-8e46-15efdfd87145.mp4

