### PR TITLE
Disable rest buttons instead of hiding them

### DIFF
--- a/css/cairn.css
+++ b/css/cairn.css
@@ -456,3 +456,47 @@ body, .window-app {
 .editor-content > p {
   padding-top: 10px;
 }
+
+/* Tooltip container */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+
+  /* Position the tooltip text - see examples below! */
+  position: absolute;
+  z-index: 1;
+
+  /* bottom tooltip */
+  /* width: 120px; */
+  /* top: 100%; */
+  /* left: 50%; */
+  /* margin-left: -60px; [> Use half of the width (120/2 = 60), to center the tooltip <] */
+
+  /* left tooltip */
+  /* top: -5px; */
+  /* right: 105%; */
+
+  /* top tooltip */
+    width: 120px;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -60px; /* Use half of the width (120/2 = 60), to center the tooltip */
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -32,24 +32,31 @@
                     data-dtype="Number"/>
                 </div>
             </div>
-            {{#unless data.deprived}}
-              <span>
-                  <button style="
-                  width: 150px;"
-                  type="button"
-                  title="Rest"
-                  class="rest">Rest
+              <span class="tooltip">
+                  <button
+                    style="width: 150px;"
+                    type="button"
+                    title="Rest"
+                    {{#if data.deprived }}
+                      disabled
+                    {{/if }}
+                    class="rest">Rest
                   </button>
-              </span>
-              <span>
+
                   <button style="
                   width: 150px;"
                   type="button"
+                  {{#if data.deprived }}
+                    disabled
+                  {{/if }}
                   title="Rest"
                   class="restore">Restore Abilities
                   </button>
+
+                  {{#if data.deprived }}
+                    <span class="tooltiptext">Cannot rest or restore abilities while deprived</span>
+                  {{/if }}
               </span>
-            {{/unless}}
         </div>
         <div class="header-fields">
             <h1 class="charname">
@@ -230,7 +237,7 @@
                         title="Delete One Item"><i class="fas fa-trash"></i></a>
                     </div>
                 </li>
-                <li class="" style="margin-left: 5px;" id="item-description-{{item._id}}">
+                <li class="" style="margin-left: 5px; display: none;" id="item-description-{{item._id}}">
                   <span>
                     {{{item.data.description}}}
                   </span>


### PR DESCRIPTION
Hopefully this makes the deprive / rest relationship a bit more obvious to player users

This should also fix the item descriptions by defaulting them to being hidden in the item list and only showing themselves when clicked on (as opposed to defaulting to being shown)