### PR TITLE
Have a more consistent height for inputs

### DIFF
--- a/css/cairn.css
+++ b/css/cairn.css
@@ -250,21 +250,19 @@ h2.background input {
 .cairn .checkbox-block {
     display: block;
 }
-/*.cairn .editor {
-    height: 100%;
-}*/
 .cairn .resource-label {
     text-align: left;
     font-size: 1rem;
     font-weight: bold;
     text-transform: uppercase;
     display: block;
-    /* height: 100%; */
     padding: 5px;
-    /* width: 90px; */
     color: white;
     background-color: black;
-    /* margin-bottom: 4px; */
+}
+.cairn .resource-input {
+    height: 32px;
+    line-height: 32px;
 }
 .cairn .sheet-tabs {
     display: flex;

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -18,18 +18,9 @@
                     class="resource-label">HP
                 </label>
                 <div class="resource-content flexrow flex-center flex-between">
-                    <input
-                    type="text"
-                    name="data.hp.value"
-                    value="{{data.data.hp.value}}"
-                    data-dtype="Number"
-                    />
-                    <span> / </span>
-                    <input
-                    type="text"
-                    name="data.hp.max"
-                    value="{{data.data.hp.max}}"
-                    data-dtype="Number"/>
+                    <input class="resource-input" type="text" name="data.hp.value" value="{{data.data.hp.value}}" data-dtype="Number"/>
+                    <span class="resource-input"> / </span>
+                    <input class="resource-input" type="text" name="data.hp.max" value="{{data.data.hp.max}}" data-dtype="Number"/>
                 </div>
             </div>
               <span class="tooltip">
@@ -86,29 +77,16 @@
                                 {{key}} <i class="fas fa-dice-d20"></i>
                             </label>
                             <div class="flexrow">
-                                <input
-                                type="text"
-                                name="data.abilities.{{key}}.value"
-                                value="{{ability.value}}"
-                                data-dtype="Number"
-                                /> <span> / </span>
-                                <input
-                                type="text"
-                                name="data.abilities.{{key}}.max"
-                                value="{{ability.max}}"
-                                data-dtype="Number"
-                                />
+                                <input class="resource-input" type="text" name="data.abilities.{{key}}.value" value="{{ability.value}}" data-dtype="Number"/> 
+                                <span class="resource-input"> / </span>
+                                <input class="resource-input" type="text" name="data.abilities.{{key}}.max" value="{{ability.max}}" data-dtype="Number"/>
                             </div>
                         </div>
                         {{/each}}
                         <div class="flexrow">
-                            <label
-                                for="data.armor"
-                            class="resource-label">Armor</label>
+                            <label for="data.armor" class="resource-label">Armor</label>
                             <div class="resource-content flexrow flex-center flex-between">
-                                <span>
-                                    {{data.data.armor}}
-                                </span>
+                                <span class="resource-input">{{data.data.armor}}</span>
                             </div>
                         </div>
                     </div>
@@ -119,14 +97,9 @@
                         <div class="flexrow">
                             <label
                                 for="data.gold"
-                            class="resource-label">gold</label>
+                            class="resource-label">Gold</label>
                             <div class="resource-content flexrow flex-center flex-between">
-                                <input
-                                type="text"
-                                name="data.gold"
-                                value="{{data.data.gold}}"
-                                data-dtype="Number"
-                                />
+                                <input class="resource-input" type="text" name="data.gold" value="{{data.data.gold}}" data-dtype="Number"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Use a more consistent height (and line height) for inputs.

Before:
![Screenshot 2022-02-16 at 23-41-58 Cairn • Foundry Virtual Tabletop](https://user-images.githubusercontent.com/12234562/154369996-83645ae9-40a4-4780-97ef-86d47df1a124.png)

After:
![Screenshot 2022-02-16 at 23-40-53 Cairn • Foundry Virtual Tabletop](https://user-images.githubusercontent.com/12234562/154370011-7c266df9-938f-402b-8378-8392d9c245a7.png)

Especially, the input for STR/DEX/WIL are now properly centered.
