### PR TITLE
Add pt-BR translation to the configuration options

### DIFF
--- a/system.json
+++ b/system.json
@@ -135,6 +135,11 @@
       "lang": "fr",
       "name": "Français",
       "path": "lang/fr.json"
+    },
+    {
+      "lang": "pt-BR",
+      "name": "Português brasileiro",
+      "path": "lang/pt-BR.json"
     }
   ],
   "gridDistance": 5,


### PR DESCRIPTION
It seems in `system.json` the new language entry was missing and in consequence not open for selection in the configuration menu of Foundry. :-)