### PR TITLE
fix: Roll strength saves for critical damage to synthetic actors against new strength

### DIFF
--- a/module/cairn.js
+++ b/module/cairn.js
@@ -73,13 +73,13 @@ Hooks.on("renderActorDirectory", (app, html) => {
 
 Hooks.on("renderChatMessage", (message, html, data) => {
   // Roll Str Save
-  const actor = game.actors.get(message.speaker?.actor);
+  const token = canvas.scene.tokens.get(message.speaker?.token);
 
-  if (actor !== undefined) {
-    if (actor.testUserPermission(game.user, "OWNER") || game.user.isGM) {
+  if (token !== undefined) {
+    if (token.actor.testUserPermission(game.user, "OWNER") || game.user.isGM) {
       html
         .find(".roll-str-save")
-        .click((ev) => Damage._rollStrSave(actor, html));
+        .click((ev) => Damage._rollStrSave(token, html));
     } else {
       html.find(".roll-str-save").each((i, btn) => {
         btn.style.display = "none";


### PR DESCRIPTION
NPC tokens use 'synthetic' actor sheets, which are essentially are the 'base' actor, plus some delta. This has been the case since foundry v11 https://foundryvtt.com/article/v11-actor-delta/

This allows (for instance) having 10 instances of a goblin token, each with their own tracked stats - but only one single 'real' actor.

Synthetic actors don't really exist, but they are synthesised as required, when the actor is obtained from a token.

Prior to this patch, the 'actor' ID was what was tracked for applying damage. This worked correctly for real actors (such as player characters) but not synthetic ones. For synthetic tokens, the STR damage would be applied correctly, but the save triggered by the "roll str save" button in chat would be against the actor's default STR (usually max STR) rather than the newly reduced STR.

This patch reworks the auto-damage code so that the token receiving the damage is tracked rather than the actor. I've tested it on both player characters and NPCs in foundry v13, and it works for both.

This patch also simplifies the applyToTarget function, which had unnecesary checks (using the ?. operator then accessing the same fields anyway). The synthetic and non-synthetic branches were otherwise identical.