### PR TITLE
item double click

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -42,6 +42,7 @@ export class CairnActorSheet extends ActorSheet {
         ? 0
         : 1
     );
+    data.items.sort((a,b) => a.name == game.i18n.localize("CAIRN.Fatigue") ? 1 : b.name == game.i18n.localize("CAIRN.Fatigue") ? -1 : 0 )
     // Compendium monsters have "description" instead of "biography"
     if (this.actor.system.showBio) {
       data.enrichedBiography = await foundry.applications.ux.TextEditor.enrichHTML(this.actor.system.biography, { async: true });
@@ -78,16 +79,7 @@ export class CairnActorSheet extends ActorSheet {
     html.find(".remove-fatigue").click(this._onRemoveFatigue.bind(this));
 
     // Update inventory item
-    html.find(".item-edit").click((ev) => {
-      const li = $(ev.currentTarget).parents(".cairn-items-list-row");
-      if (li.data("isContainer")) {
-        const item = this.actor.getOwnedContainer(li.data("itemId"));
-        item.sheet.render(true);
-        return;
-      }
-      const item = this.actor.getOwnedItem(li.data("itemId"));
-      item.sheet.render(true);
-    });
+    html.find(".item-edit").click((ev) => this._onItemEditToggle(ev));
 
     // Delete inventory item
     html.find(".item-delete").click((ev) => {
@@ -183,6 +175,10 @@ export class CairnActorSheet extends ActorSheet {
       .click((event) => this._onItemDescriptionToggle(event));
 
     html
+      .find(".cairn-item-title")
+      .dblclick((event) => this._onItemEditToggle(event));
+
+    html
       .find(".cairn-feature-title")
       .click((event) => this._onFeatureDescriptionToggle(event));      
 
@@ -193,6 +189,18 @@ export class CairnActorSheet extends ActorSheet {
         flavor: game.i18n.localize("CAIRN.DieOfFate"),
       });
     });
+  }
+
+  async _onItemEditToggle(ev) {
+    const li = $(ev.currentTarget).parents(".cairn-items-list-row");
+      if (li.data("isContainer")) {
+        const item = this.actor.getOwnedContainer(li.data("itemId"));
+        item.sheet.render(true);
+        return;
+      }
+      const item = this.actor.getOwnedItem(li.data("itemId"));
+      if (item.name == game.i18n.localize("CAIRN.Fatigue")) return;
+      item.sheet.render(true);
   }
 
   /* -------------------------------------------- */

--- a/module/cairn.js
+++ b/module/cairn.js
@@ -171,6 +171,10 @@ const configureHandleBar = () => {
     return val !== null && val != undefined;
   });
 
+ Handlebars.registerHelper("isFatigue", function (val) {
+    return val == game.i18n.localize("CAIRN.Fatigue");
+  });
+
   Handlebars.registerHelper("not", function (val) {
     return !val;
   });

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -30,8 +30,8 @@ export class CairnItemSheet extends ItemSheet {
   /** @override */
   async getData() {
     const data = await super.getData();
-    data.enrichedDescription = await TextEditor.enrichHTML(data.item.system.description, { async: true });
-    data.enrichedCriticalDamage = await TextEditor.enrichHTML(data.item.system.criticalDamage, { async: true });
+    data.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(data.item.system.description, { async: true });
+    data.enrichedCriticalDamage = await foundry.applications.ux.TextEditor.implementation.enrichHTML(data.item.system.criticalDamage, { async: true });
     return data;
   }
 

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -18,6 +18,8 @@ export class CairnItem extends Item {
       if (this.system.uses.value > this.system.uses.max)
         this.system.uses.value = this.system.uses.max;
     }
+    this.system.isFatigue = this.name == game.i18n.localize("CAIRN.Fatigue");
+
     this.system.useItemIcons = game.settings.get("cairn", "use-item-icons");
     if (this.system.useItemIcons) {
       this.system.icon = "";
@@ -30,6 +32,11 @@ export class CairnItem extends Item {
           break;
         case "armor":
           this.system.icon = "shield";
+          break;
+        case "item":
+          if (this.name == game.i18n.localize("CAIRN.Fatigue")) {
+            this.system.icon = "weight-hanging";
+          }
           break;
       }
     }

--- a/module/macros.js
+++ b/module/macros.js
@@ -91,7 +91,7 @@ export const rollItemMacro = async (actorId, itemId) => {
   const rollMessageTpl = "systems/cairn/templates/chat/dmg-roll-card.html";
   const tplData = { label: label, targets: targetIds };
   const msg = await renderTemplate(rollMessageTpl, tplData);
-  roll.toMessage({
+  roll.toMessage({    
     speaker: ChatMessage.getSpeaker({ actor: actor }),
     flavor: msg,
   });

--- a/system.json
+++ b/system.json
@@ -4,7 +4,7 @@
   "description": "Cairn for FoundryVTT",
   "version": "0.23",
   "compatibility": {
-    "minimum": "12",
+    "minimum": "13",
     "verified": "13.346"
   },
   "license": "LICENSE.txt",

--- a/templates/parts/items-list.html
+++ b/templates/parts/items-list.html
@@ -94,7 +94,9 @@
       </a>
       {{/if}}
 
+      {{#if (not item.system.isFatigue) }}
       <a class="item-control item-edit" title="{{ localize 'CAIRN.EditItem' }}"><i class="fas fa-edit"></i></a>
+      {{/if}}
       <a class="item-control item-delete" title="{{ localize 'CAIRN.DeleteItem' }}"><i class="fas fa-trash"></i></a>
     </div>
   </div>


### PR DESCRIPTION
- Fatigue at the end of equipment list
- Double click on item shows editor window
- Minimum Foundry version 13 - because of removing some deprecated calls, it is no longer compatible with the version 12 