### PR TITLE
Fix coloration on Succ/Fail saves

### DIFF
--- a/css/cairn.css
+++ b/css/cairn.css
@@ -531,6 +531,14 @@
     font-style: italic;
 }
 
+.dice-roll .dice-total.success {
+    color: #2E7D32
+}
+
+.dice-roll .dice-total.failure {
+    color: #C62828
+}
+
 .indent {
     margin-left: 16px;
 }


### PR DESCRIPTION
This is a fix to show popper coloration on Successful / Failed Saves.

Resolves https://github.com/yochaigal/Cairn-FoundryVTT/issues/157#issue-3473036275 if you are interested.  

<img width="345" height="255" alt="Screenshot From 2025-10-10 21-00-06" src="https://github.com/user-attachments/assets/d4f5481e-4121-4be1-86a2-ae7ed0edcb5b" />
