### PR TITLE
Add a setting which allows storing gold in containers.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -52,7 +52,7 @@
     "ConfirmDelete": "Delete"
   },
   "CAIRN.Owner": "Owner",
-  "CAIRN.OverburdenByGold": "Character may be overburdened by a gold",
+  "CAIRN.OverburdenByGold": "Character may be overburdened by gold",
   "CAIRN.Quantity": "Quantity",
   "CAIRN.Panicked": "Panicked",
   "CAIRN.RemoveFatigue": "Remove fatigue",
@@ -75,6 +75,11 @@
       "label": "Use gold threshold",
       "hint": "Define number of gold pieces which occupies full inventory slot. Zero means that gold pieces are always petty.",
       "message": "Gold is counted as an inventory"
+    },
+    "ShowGoldNotCost": {
+      "label": "Show gold instead of cost on containers",
+      "hint": "This allows putting gold (including weight tracking) inside containers.",
+      "message": "Gold weight is rounded up instead of down when tracked in containers."
     },
     "UsePanic": {
       "label": "Use panic condition",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -60,7 +60,7 @@ export class CairnActor extends Actor {
     const gct = game.settings.get("cairn", "use-gold-threshold");
     this.system.hasGoldThreshold = gct > 0;
     if (this.system.hasGoldThreshold > 0 && this.system.gold) {
-      this.system.goldSlots = Math.floor(this.system.gold / gct);
+      this.system.goldSlots = this._calcGoldSlots();
     }
 
     if (this.system.encumbered) {
@@ -75,7 +75,19 @@ export class CairnActor extends Actor {
       this.system.hp.value = 0;
     }
 
-    this.system.characterEquipmentLimit = game.settings.get("cairn", "character-inventory-limit");    
+    this.system.characterEquipmentLimit = game.settings.get("cairn", "character-inventory-limit");
+  }
+
+  _calcGoldSlots() {
+    const gct = game.settings.get("cairn", "use-gold-threshold");
+    if (gct > 0 && this.system.gold) {
+      if (this.type === "container") {
+        return Math.ceil(this.system.gold / gct);
+      } else {
+        return Math.floor(this.system.gold / gct);
+      }
+    }
+    return 0;
   }
 
   _prepareNpcData() {
@@ -91,6 +103,7 @@ export class CairnActor extends Actor {
     this.system.slotsMax = this.calcCurrentMaxSlots();
     this.system.encumbered =
       this.system.slotsUsed >= this.calcCurrentMaxSlots();
+    this.system.maybeTooMuchGold = false;
     if (this.system.keeper && this.system.keeper != "") {
       const actor = game.actors.find((a) => a.uuid == this.system.keeper);
       if (actor) {
@@ -98,6 +111,16 @@ export class CairnActor extends Actor {
           game.i18n.localize("CAIRN.Owner") + ": " + actor.name;
       }
     }
+
+    const gct = game.settings.get("cairn", "use-gold-threshold");
+    this.system.hasGoldThreshold = gct > 0;
+    this.system.goldSlots = this._calcGoldSlots();
+    if (this.system.encumbered) {
+      if (this.system.hasGoldThreshold && this.system.goldSlots > 0) {
+        this.system.maybeTooMuchGold = true;
+      }
+    }
+    this.system.showGoldNotCost = game.settings.get("cairn", "show-gold-not-cost");
   }
 
   /** @override */
@@ -237,7 +260,7 @@ export class CairnActor extends Actor {
     );
     const goldThreshold = game.settings.get("cairn", "use-gold-threshold");
     if (goldThreshold > 0 && this.system.gold) {
-      totalSlots += Math.floor(this.system.gold / goldThreshold);
+      totalSlots += this._calcGoldSlots();
     }
     return totalSlots;
   }

--- a/module/settings.js
+++ b/module/settings.js
@@ -19,6 +19,16 @@ export const registerSettings = () => {
     requiresReload: true,
   });
 
+  game.settings.register("cairn", "show-gold-not-cost", {
+    name: game.i18n.localize("CAIRN.Settings.ShowGoldNotCost.label"),
+    hint: game.i18n.localize("CAIRN.Settings.ShowGoldNotCost.hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+    requiresReload: true,
+  });
+
   game.settings.register("cairn", "use-panic", {
     name: game.i18n.localize("CAIRN.Settings.UsePanic.label"),
     hint: game.i18n.localize("CAIRN.Settings.UsePanic.hint"),

--- a/templates/actor/container-sheet.html
+++ b/templates/actor/container-sheet.html
@@ -16,14 +16,27 @@
                            value="{{data.system.slots.value}}" data-dtype="Number" />
                 </div>
             </div>
-             <!-- Cost -->
-            <div class="resource-counter slots-counter">
-                <label class="large-resource-label" for="system.cost.value">{{ localize 'CAIRN.Cost' }}</label>
-                <div class="resource-input-wrapper">
-                    <input type="text" name="system.cost.value" id="system.cost.value"
-                        value="{{data.system.cost.value}}" data-dtype="Number" />
+             <!-- Cost/Gold -->
+            {{#if data.system.showGoldNotCost }}
+                <div class="resource-counter slots-counter {{#if data.system.maybeTooMuchGold }}overburdened-gold{{/if}}"
+                {{#if data.system.maybeTooMuchGold }} title="{{localize 'CAIRN.OverburdenByGold'}}" {{/if}} >
+                    <label for="system.gold" >
+                        {{ localize 'CAIRN.Gold' }}
+                    </label>
+                    <div class="resource-input-wrapper">
+                        <input type="number" name="system.gold" id="system.gold" value="{{data.system.gold}}" data-dtype="Number" />
+                    </div>
                 </div>
-            </div>
+            {{else}}
+                <div class="resource-counter slots-counter">
+                    <label class="large-resource-label" for="system.cost.value">{{ localize 'CAIRN.Cost' }}</label>
+                    <div class="resource-input-wrapper">
+                        <input type="text" name="system.cost.value" id="system.cost.value"
+                            value="{{data.system.cost.value}}" data-dtype="Number" />
+                    </div>
+                </div>
+            {{/if}}
+
         </div>
         <div class="character-sheet-section-tabs">
             <nav class="tabs" data-group="primary">


### PR DESCRIPTION
This setting (disabled by default) removes the 'cost' field in containers, and replaces it with a 'gold' field.

The reasoning for this was to allow players to use containers to store shared loot (or their own gold in personal containers).

This also works with the 'gold slots' feature, however unlike characters, any amount of gold in a container is non-petty.

I put this behind a setting so as not to break anyone, but I don't really understand the purpose of the previous "cost" field. Maybe it doesn't need to be behind a setting. If I understood CSS better, then maybe they could both be there at the same time.